### PR TITLE
update core_dump.sh

### DIFF
--- a/ZSST_Linux/share/support_tool/actions/core_dump.sh
+++ b/ZSST_Linux/share/support_tool/actions/core_dump.sh
@@ -108,17 +108,17 @@ cp $ZCE_PREFIX/share/support_tool/gdb_adv.sh $ZCE_PREFIX/var/core
 chmod a+x $ZCE_PREFIX/var/core/gdb_adv.sh
 
 # not including 'php-$PHP_VER-fcgi-zend-server-dbg' because it seems to cause bogus conflict in YUM
-DBG_COMMON="gdb zend-server-php-$PHP_VER-dbg php-$PHP_VER-bin-zend-server-dbg"
+DBG_COMMON="gdb zend-server-php-dbg php-bin-zend-server-dbg"
 
 if command -v apt-get 2> /dev/null; then
 	REPOFILE="/etc/apt/sources.list.d/zend.list"
 	otherrepo $REPOFILE $RELEASE
-	DBG_PHP_BIN="php-$PHP_VER-fpm-zend-server-dbg"
+	DBG_PHP_BIN="php-fpm-zend-server-dbg"
 	if [ "$WEB_SRV" = "apache" ]; then
 		SAPI=$(grep -E '^\s*zend.php_sapi\s*=' $ZCE_PREFIX/etc/ZendGlobalDirectives.ini | sed 's@ @@g' | cut -d '=' -f 2)
 		set_core_dump_confs apache2
 		if [ "$SAPI" != "fpm" ]; then
-			DBG_PHP_BIN="libapache2-mod-php-$PHP_VER-zend-server-dbg"
+			DBG_PHP_BIN="libapache2-mod-php-zend-server-dbg"
 		fi
 	elif [ "$WEB_SRV" = "nginx" ]; then
 		set_core_dump_confs nginx
@@ -129,12 +129,12 @@ if command -v apt-get 2> /dev/null; then
 elif command -v yum 2> /dev/null; then
 	REPOFILE="/etc/yum.repos.d/zend.repo"
 	otherrepo $REPOFILE $RELEASE
-	DBG_PHP_BIN="php-$PHP_VER-fpm-zend-server-dbg"
+	DBG_PHP_BIN="php-fpm-zend-server-dbg"
 	if [ "$WEB_SRV" = "apache" ]; then
 		SAPI=$(grep -E '^\s*zend.php_sapi' $ZCE_PREFIX/etc/ZendGlobalDirectives.ini | sed 's@ @@g' | cut -d '=' -f 2)
 		set_core_dump_confs httpd
 		if [ "$SAPI" != "fpm" ]; then
-			DBG_PHP_BIN="mod-php-$PHP_VER-apache2-zend-server-dbg"
+			DBG_PHP_BIN="mod-php-apache2-zend-server-dbg"
 		fi
 	elif [ "$WEB_SRV" = "nginx" ]; then
 		set_core_dump_confs nginx


### PR DESCRIPTION
This commit is for removing $PHP_VER variable from package names in core_dump.sh file so that the "/usr/local/zend/bin/support_tool.sh --core-dump" works correctly..