### PR TITLE
Minor correction in core_dump.sh

### DIFF
--- a/ZSST_Linux/share/support_tool/actions/core_dump.sh
+++ b/ZSST_Linux/share/support_tool/actions/core_dump.sh
@@ -108,7 +108,7 @@ cp $ZCE_PREFIX/share/support_tool/gdb_adv.sh $ZCE_PREFIX/var/core
 chmod a+x $ZCE_PREFIX/var/core/gdb_adv.sh
 
 # not including 'php-$PHP_VER-fcgi-zend-server-dbg' because it seems to cause bogus conflict in YUM
-DBG_COMMON="gdb zend-server-php-dbg php-bin-zend-server-dbg"
+DBG_COMMON="gdb zend-server-dbg php-bin-zend-server-dbg"
 
 if command -v apt-get 2> /dev/null; then
 	REPOFILE="/etc/apt/sources.list.d/zend.list"


### PR DESCRIPTION
ST --core-dump is broken on DEB based OS...it results in "E: Unable to locate package zend-server-php-dbg" error. Also, on RPM OS, it doesn't include the package "zend-server-dbg". To fix this, corrected the package name in core_dump.sh on line 111.